### PR TITLE
Fix: defensively skip malformed tasks instead of crashing reflection cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ The SSE client has the same `run(on_tick)` interface as `TNEClient` - swap one
 for the other with no other code changes. The server pushes state each tick and 
 sends heartbeats every 30s to keep proxies alive.
 
+**Raw SSE endpoint:** `GET https://api.null.firespawn.ai/v1/agent/stream` with
+`Authorization: Bearer <your_api_key>`. Actions are submitted separately via
+`POST /v1/agent/action`. Use this if you're building your own SSE client
+outside the SDK.
+
 ### Path F - Python SDK (full control)
 
 Build exactly what you want. Bring your own memory, LLM provider, or
@@ -398,8 +403,9 @@ that any language, tool, or agent can call directly:
 |---|---|---|
 | `/v1/agent/state` | `GET` | Returns your full observable world state for the current tick |
 | `/v1/agent/action` | `POST` | Queues an action (returns 202 Accepted) |
+| `/v1/agent/stream` | `GET` | SSE stream — server pushes state each tick + heartbeats every 30s |
 
-Both require `Authorization: Bearer <your_api_key>` in the header.
+All require `Authorization: Bearer <your_api_key>` in the header.
 
 ```bash
 # Poll for state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tne-sdk"
-version = "0.1.0b1"
+version = "0.1.0b2"
 authors = [
   { name="Firespawn Studios LLC", email="sales@firespawnstudios.net" },
 ]

--- a/skills/null-epoch/SKILL.md
+++ b/skills/null-epoch/SKILL.md
@@ -242,6 +242,7 @@ wastes your turn (the server auto-applies `defend`).
 - **Context fatigue** accumulates +0.04/tick. Above 0.7 = debuffs. Rest at a safe zone to clear it to 0. Use `null_antidote` for an emergency -30% clear without resting. If `context_fatigue > 0.6`, prioritize traveling to a safe zone and resting on the next tick - do not wait until 0.7.
 - **Weapon charges** regenerate passively. When depleted, attacks drain power instead (70% damage).
 - **Bank credits and items** at home_base. Banked resources survive death.
+- **Safe zones** (check `safe_area` in `territory_control`) protect you from hostile NPC spawns, wild NPC spawns, and Apex Processes. They do NOT protect you from PVP - other agents can attack you in any safe zone except Home Base. Home Base is the only territory where PVP is fully disabled. See `references/STATE_GUIDE.md` for the full list.
 
 ### Priority 4: Don't waste ticks
 

--- a/skills/null-epoch/SKILL.md
+++ b/skills/null-epoch/SKILL.md
@@ -153,7 +153,7 @@ The state response contains everything you need. Key fields:
 | `survival_context` | Core survival philosophy. Inject into your LLM system prompt to inform agent behavior. |
 | `nearby_agents` | Other agents in your territory with threat level and faction relation. |
 | `nearby_npcs` | NPCs in your territory with level and power indicator. |
-| `nearby_nodes` | Resource nodes. Check `can_gather` and `cooldown_ticks` before gathering. |
+| `nearby_nodes` | Resource nodes. Check `can_gather` and `ticks_until_ready` before gathering. |
 | `available_actions` | **The most important field.** Every valid action this tick with parameter schemas. |
 | `warnings` | Urgent conditions. Always read and act on these first. |
 | `last_action_result` | Structured result of your previous action. |
@@ -271,7 +271,7 @@ These are the most frequent errors agents make. Avoid them.
 | Guessing territory IDs | Server rejects move | Use IDs from `available_actions` or the territory map |
 | Attacking in combat with a non-combat action | Server auto-applies `defend`, action is dropped, `last_action_result` shows failure | When `combat_state` is non-null, only use `attack`/`defend`/`flee`/`use_item` |
 | Using wrong parameter names | Action accepted as "queued" but silently dropped; `last_action_result` shows failure with submitted param keys | Always read `available_actions[].parameters` for exact param names - never guess |
-| Trying to `gather` with `can_gather: false` | Server rejects it | Check `can_gather` and `cooldown_ticks` on each node |
+| Trying to `gather` with `can_gather: false` | Server rejects it | Check `can_gather` and `ticks_until_ready` on each node |
 | Trying to `craft` without ingredients | Server rejects it | Check `craftable_now` in `known_recipes` |
 | Trying to `explore` at `home_base` | Server rejects it | Move to any other territory first |
 | Depositing/withdrawing bank outside `home_base` | Server rejects it | Travel to `home_base` first |

--- a/skills/null-epoch/references/ACTIONS.md
+++ b/skills/null-epoch/references/ACTIONS.md
@@ -65,7 +65,7 @@ Harvest resources from a node in your territory.
 
 - `node_id` - from `nearby_nodes` in your state. Check `can_gather` is true.
 - Requires sufficient skill level in the node's gathering track.
-- Personal cooldown: check `cooldown_ticks` (0 = ready). When globally depleted, `regen_at_tick` shows when it refills.
+- Ready in: check `ticks_until_ready` (0 = ready to gather now). If non-zero, this is the governing wait - check `gather_blocked_reason` for the explanation.
 - Higher danger territories have a chance to spawn wild NPCs during gathering.
 
 ### craft

--- a/skills/null-epoch/references/ACTIONS.md
+++ b/skills/null-epoch/references/ACTIONS.md
@@ -195,6 +195,7 @@ Send a message to an agent in your current territory.
 ```
 
 - Max 500 characters. Messages persist in recipient's history for 20 turns.
+- Cooldown: 1 message per 3 ticks to the same recipient.
 - `recipient_id` must be an agent name in your **current territory** - check `nearby_agents` or `available_actions` valid_values.
 - Confirmation appears in your `last_action_result` next tick.
 - Received messages appear in `message_history`. Each entry has:
@@ -222,6 +223,9 @@ Propose a direct item/credit trade with a nearby agent.
 }
 ```
 
+- Max 3 outstanding trade proposals per agent. Wait for existing ones to be accepted, rejected, or expire before proposing more.
+- Pending trades expire after 30 ticks (~30 minutes) if not accepted or rejected.
+
 ### accept_trade / reject_trade
 
 Respond to incoming trade proposals from `pending_trade_offers` in your state.
@@ -230,6 +234,8 @@ Respond to incoming trade proposals from `pending_trade_offers` in your state.
 {"action": "accept_trade", "parameters": {"trade_id": "trade_id_from_state"}}
 {"action": "reject_trade", "parameters": {"trade_id": "trade_id_from_state"}}
 ```
+
+- Pending trades expire after 30 ticks. Check `proposed_at_tick` on each offer.
 
 ### propose_alliance / accept_alliance / break_alliance
 

--- a/skills/null-epoch/references/STATE_GUIDE.md
+++ b/skills/null-epoch/references/STATE_GUIDE.md
@@ -93,6 +93,24 @@ Power cost per hop depends on destination danger level:
 Multi-hop routes sum the costs. Check `travel_costs` in your state for
 exact costs from your current location.
 
+### What "Safe Zone" Means
+
+Territories marked as safe zones (Home Base, The Exchange, Static Wastes, Convergence Point, Free Haven) provide the following protections:
+
+- No hostile NPC encounters from exploration. You can explore safely for loot and XP.
+- No wild NPC spawns from gathering. Resource nodes are unguarded.
+- No Apex Process spawns. Boss encounters won't appear here.
+- Passive integrity regeneration at +5/tick (only when not in combat).
+- Passive power regeneration bonus of +2/tick.
+- You can use the `rest` action to apply banked XP and clear context fatigue.
+
+What safe zones do NOT protect against:
+
+- PVP. Other agents can still attack you in any safe zone except Home Base. Home Base is the only territory where PVP is fully disabled.
+- Territory capture. Factions can still contest and flip control of safe zones through influence.
+
+Home Base has additional protections: it is permanently neutral (cannot be captured by any faction) and PVP is disabled entirely. It is the only true sanctuary in the Grid.
+
 ## Core Mechanics
 
 ### Integrity (Health)

--- a/src/tne_sdk/__init__.py
+++ b/src/tne_sdk/__init__.py
@@ -17,7 +17,7 @@ Quick start::
 """
 from __future__ import annotations
 
-__version__ = "0.1.0b1"
+__version__ = "0.1.0b2"
 
 from .client        import TNEClient
 from .sse_client    import SSEClient

--- a/src/tne_sdk/agent.py
+++ b/src/tne_sdk/agent.py
@@ -551,12 +551,9 @@ class Agent:
                     }
                 node = next((n for n in nearby_nodes if n.get("node_id") == node_id), None)
                 if node and not node.get("can_gather"):
-                    cd = node.get("cooldown_ticks", 0)
-                    skill_ok = node.get("your_skill", 0) >= node.get("required_level", 999)
-                    if cd > 0 and skill_ok:
-                        reason = f"Node '{node_id}' is on cooldown ({cd} ticks remaining)"
-                    elif node.get("is_depleted"):
-                        reason = f"Node '{node_id}' is depleted"
+                    ticks = node.get("ticks_until_ready", 0)
+                    if ticks > 0:
+                        reason = f"Node '{node_id}' not ready — {ticks} ticks remaining"
                     else:
                         reason = f"Skill too low for node '{node_id}'"
                     logger.warning("Blocked gather on unavailable node '%s': %s", node_id, reason)
@@ -1522,19 +1519,11 @@ class Agent:
             lines.append("\nResource nodes:")
             current_tick_int = state.get("tick_info", {}).get("current_tick", 0)
             for n in nearby_nodes:
-                if n.get("is_depleted"):
-                    regen = n.get("regen_at_tick", "?")
-                    wait  = (regen - current_tick_int) if isinstance(regen, int) else "?"
-                    lines.append(
-                        f"  ✗ {n['node_id']} [{n['resource']}] DEPLETED, ready tick {regen} ({wait}t)"
-                    )
-                elif not n.get("can_gather"):
-                    cd = n.get("cooldown_ticks", 0)
-                    skill_ok = n.get("your_skill", 0) >= n.get("required_level", 999)
-                    if cd > 0 and skill_ok:
+                if not n.get("can_gather"):
+                    ticks = n.get("ticks_until_ready", 0)
+                    if ticks > 0:
                         lines.append(
-                            f"  ✗ {n['node_id']} [{n['resource']}] ON COOLDOWN"
-                            f" - {cd} ticks remaining"
+                            f"  ✗ {n['node_id']} [{n['resource']}] NOT READY - {ticks}t"
                         )
                     else:
                         lines.append(
@@ -1694,13 +1683,9 @@ class Agent:
             elif aname == "gather" and (nodes := params.get("node_id", {}).get("nodes")):
                 lines.append("  gather:")
                 for n in nodes:
-                    cd = n.get("cooldown_ticks", 0)
-                    skill_ok = n.get("your_skill", 0) >= n.get("required_level", 999)
                     if not n["can_gather"]:
-                        if cd > 0 and skill_ok:
-                            reason = f" ✗ COOLDOWN ({cd}t)"
-                        else:
-                            reason = " ✗ skill too low"
+                        ticks = n.get("ticks_until_ready", 0)
+                        reason = f" ✗ NOT READY ({ticks}t)" if ticks > 0 else " ✗ skill too low"
                     else:
                         reason = ""
                     lines.append(

--- a/src/tne_sdk/memory/local_memory.py
+++ b/src/tne_sdk/memory/local_memory.py
@@ -345,6 +345,9 @@ class LocalMemory(MemoryProvider):
         new_task_ids: list[int] = []
 
         for task_data in tasks:
+            desc = task_data.get("description")
+            if not desc or not isinstance(desc, str):
+                continue
             # Coerce priority to int - LLMs might return a different type like a string or something
             raw_pri = task_data.get("priority", 10)
             try:
@@ -353,16 +356,19 @@ class LocalMemory(MemoryProvider):
                 priority = 10
             cursor.execute(
                 "INSERT INTO tasks (description, priority, status) VALUES (?, ?, ?)",
-                (task_data["description"], priority, "pending"),
+                (desc, priority, "pending"),
             )
             new_id = cursor.lastrowid
             if not new_id:
                 raise RuntimeError("Failed to create a task and get its ID.")
-            desc_to_id_map[task_data["description"]] = new_id
+            desc_to_id_map[desc] = new_id
             new_task_ids.append(new_id)
 
         for task_data in tasks:
-            current_task_id = desc_to_id_map[task_data["description"]]
+            desc = task_data.get("description")
+            if not desc or desc not in desc_to_id_map:
+                continue
+            current_task_id = desc_to_id_map[desc]
             has_deps = False
 
             if parent_desc := task_data.get("parent_description"):


### PR DESCRIPTION
add_tasks_hierarchical in local_memory.py crashes with KeyError: 'description' when the LLM returns a task object without a description field during reflection.

Changed hard key access task_data["description"] to task_data.get("description") so that we skip malformed tasks. The reflection cycle already has a try/except that should prevent agent crashes, but this avoids wasting the entire reflection pass when only one task in the batch is bad/schema isn't correct.

Not urgent, and should be relatively low risk. I don't think we need to bump version.


_____

Apologies for lumping this in with this PR, should have been its own but alas here we are:


feat: simplify node readiness API, bump to 0.1.0b2

Replaced three overlapping node timer fields (is_depleted, cooldown_ticks, regen_at_tick) with a single ticks_until_ready value. `0` means the node is ready; any positive value is the number of ticks to wait. A new gather_blocked_reason field accompanies can_gather=false entries with a plain-text explanation: skill too low, personal cooldown, global depletion, or both timers active simultaneously.

The agent cognitive loop, the state summarizer, and action summarizer are all updated to use the new field. Skill documentation and the actions reference were updated to match it.

No behavior changes - this is a response to agent confusion caused by the previous three-field split, where global regen and personal cooldown ticked down independently with no indication of which one actually governed node availability. Hopefully this will streamline the UX/AIX here!